### PR TITLE
Removing pysha3 as a dependency, updating others

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ certifi==2019.3.9
 chardet==3.0.4
 coverage==4.5.3
 coveralls==1.8.0
-cytoolz==0.9.0.1
+cytoolz==0.12.2
 docopt==0.6.2
 eth-abi==1.3.0
 eth-account==0.3.0
@@ -17,7 +17,7 @@ eth-typing==2.1.0
 eth-utils==1.6.0
 hexbytes==0.2.0
 idna==2.8
-importlib-metadata==0.17
+importlib-metadata==6.8.0
 lru-dict==1.1.6
 more-itertools==7.0.0
 packaging==19.0
@@ -26,7 +26,6 @@ pluggy==0.12.0
 py==1.8.0
 pycryptodome==3.8.2
 pyparsing==2.4.0
-pysha3==1.0.2
 pytest==4.6.2
 pytest-cov==2.7.1
 requests==2.22.0


### PR DESCRIPTION
Presently, this is as small and surgical as is fit to pass the test suite.

If the preference is for a broader dependency update, I can do that too.